### PR TITLE
chore: AP-1156 config cleanup

### DIFF
--- a/tenant.yaml
+++ b/tenant.yaml
@@ -26,77 +26,7 @@ resourceServers:
     token_dialect: access_token_authz
     token_lifetime: 86400
     token_lifetime_for_web: 7200
-  - name: ConvEngine API (Test)
-    identifier: http://convengine.com
-    allow_offline_access: false
-    signing_alg: RS256
-    skip_consent_for_verifiable_first_party_clients: true
-    token_lifetime: 86400
-    token_lifetime_for_web: 7200
 clients:
-  - name: AP Admin API
-    app_type: regular_web
-    cross_origin_auth: false
-    custom_login_page_on: true
-    grant_types:
-      - authorization_code
-      - implicit
-      - refresh_token
-      - client_credentials
-    is_first_party: true
-    is_token_endpoint_ip_header_trusted: false
-    jwt_configuration:
-      alg: RS256
-      lifetime_in_seconds: 36000
-      secret_encoded: false
-    oidc_conformant: true
-    refresh_token:
-      expiration_type: non-expiring
-      leeway: 0
-      infinite_token_lifetime: true
-      infinite_idle_token_lifetime: true
-      token_lifetime: 31557600
-      idle_token_lifetime: 2592000
-      rotation_type: non-rotating
-    sso_disabled: false
-    token_endpoint_auth_method: client_secret_post
-  - name: AP frontend
-    allowed_clients: []
-    allowed_logout_urls: @@APP_ORIGINS@@
-    allowed_origins: @@APP_ORIGINS@@
-    app_type: spa
-    callbacks: @@APP_CALLBACKS@@
-    client_aliases: []
-    cross_origin_auth: false
-    custom_login_page_on: true
-    grant_types:
-      - authorization_code
-      - refresh_token
-    is_first_party: true
-    is_token_endpoint_ip_header_trusted: false
-    jwt_configuration:
-      alg: RS256
-      lifetime_in_seconds: 36000
-      secret_encoded: false
-    native_social_login:
-      apple:
-        enabled: false
-      facebook:
-        enabled: false
-    oidc_conformant: true
-    organization_require_behavior: no_prompt
-    organization_usage: allow
-    refresh_token:
-      expiration_type: expiring
-      leeway: 0
-      token_lifetime: 2592000
-      idle_token_lifetime: 1296000
-      infinite_token_lifetime: false
-      infinite_idle_token_lifetime: false
-      rotation_type: rotating
-    sso_disabled: false
-    token_endpoint_auth_method: none
-    web_origins: @@APP_ORIGINS@@
   - name: API Explorer Application
     app_type: non_interactive
     cross_origin_auth: false
@@ -132,29 +62,6 @@ clients:
       - authorization_code
       - implicit
       - refresh_token
-      - client_credentials
-    is_first_party: true
-    is_token_endpoint_ip_header_trusted: false
-    jwt_configuration:
-      alg: RS256
-      lifetime_in_seconds: 36000
-      secret_encoded: false
-    oidc_conformant: true
-    refresh_token:
-      expiration_type: non-expiring
-      leeway: 0
-      infinite_token_lifetime: true
-      infinite_idle_token_lifetime: true
-      token_lifetime: 31557600
-      idle_token_lifetime: 2592000
-      rotation_type: non-rotating
-    sso_disabled: false
-    token_endpoint_auth_method: client_secret_post
-  - name: ConvEngine API (Test) (Test Application)
-    app_type: non_interactive
-    cross_origin_auth: false
-    custom_login_page_on: true
-    grant_types:
       - client_credentials
     is_first_party: true
     is_token_endpoint_ip_header_trusted: false
@@ -239,19 +146,13 @@ clients:
     web_origins: @@APP_ORIGINS@@
   - name: Sample App
     allowed_clients: []
-    allowed_logout_urls: @@APP_ORIGINS@@
-    allowed_origins: []
-    app_type: spa
-    callbacks: @@APP_CALLBACKS@@
+    app_type: non_interactive
+    callbacks: []
     client_aliases: []
-    client_metadata:
-      asdf: asdf
     cross_origin_auth: false
     custom_login_page_on: true
     grant_types:
-      - authorization_code
-      - implicit
-      - refresh_token
+      - client_credentials
     is_first_party: true
     is_token_endpoint_ip_header_trusted: false
     jwt_configuration:
@@ -263,32 +164,6 @@ clients:
         enabled: false
       facebook:
         enabled: false
-    oidc_conformant: true
-    organization_require_behavior: no_prompt
-    organization_usage: allow
-    refresh_token:
-      expiration_type: expiring
-      leeway: 0
-      token_lifetime: 2592000
-      idle_token_lifetime: 1296000
-      infinite_token_lifetime: false
-      infinite_idle_token_lifetime: false
-      rotation_type: rotating
-    sso_disabled: false
-    token_endpoint_auth_method: none
-    web_origins: @@APP_ORIGINS@@
-  - name: User Manager
-    app_type: non_interactive
-    cross_origin_auth: false
-    custom_login_page_on: true
-    grant_types:
-      - client_credentials
-    is_first_party: true
-    is_token_endpoint_ip_header_trusted: false
-    jwt_configuration:
-      alg: RS256
-      lifetime_in_seconds: 36000
-      secret_encoded: false
     oidc_conformant: true
     refresh_token:
       expiration_type: non-expiring
@@ -327,13 +202,10 @@ databases:
   - name: BotEngine
     strategy: auth0
     enabled_clients:
-      - AP frontend
       - API Explorer Application
       - auth0-deploy-cli-extension
-      - ConvEngine API (Test) (Test Application)
       - Login-UI
-      - Sample App
-      - User Manager
+      - User Management API
     is_domain_connection: false
     options:
       mfa:
@@ -394,20 +266,15 @@ tenant:
     disable_clickjack_protection_headers: false
   friendly_name: e-bot7 (beta)
   picture_url: https://cdn.e-bot7.com/wp-content/uploads/e-bot7-logo-dark.svg
-  support_email: ""
-  support_url: ""
+  support_email: ''
+  support_url: ''
   universal_login:
     colors:
-      page_background: "#000000"
-      primary: "#24ff7d"
+      page_background: '#000000'
+      primary: '#24ff7d'
 emailProvider: {}
 emailTemplates: []
 clientGrants:
-  - client_id: AP Admin API
-    audience: https://example.com/botengine
-    scope:
-      - read:messages
-      - write:messages
   - client_id: API Explorer Application
     audience: https://dev-zf0bz1nz.eu.auth0.com/api/v2/
     scope:
@@ -541,10 +408,7 @@ clientGrants:
       - create:organization_invitations
       - read:organization_invitations
       - delete:organization_invitations
-  - client_id: ConvEngine API (Test) (Test Application)
-    audience: http://convengine.com
-    scope: []
-  - client_id: User Manager
+  - client_id: User Management API
     audience: https://dev-zf0bz1nz.eu.auth0.com/api/v2/
     scope:
       - read:client_grants
@@ -721,8 +585,8 @@ roles:
     permissions: []
 branding:
   colors:
-    page_background: "#000000"
-    primary: "#24ff7d"
+    page_background: '#000000'
+    primary: '#24ff7d'
   logo_url: https://cdn.e-bot7.com/wp-content/uploads/e-bot7-logo-dark.svg
 prompts:
   universal_login_experience: new

--- a/tenant.yaml
+++ b/tenant.yaml
@@ -1,5 +1,5 @@
 rules:
-  - name: Set roles to a user
+  - name: setRolesToUser
     script: ./rules/setRolesToUser.js
     stage: login_success
     enabled: true


### PR DESCRIPTION
- Remove clients that shouldn't be used (yes, that's the one that caused the logout issues).
- Some minor fixes to make auth0 configuration exports consistent.