### PR TITLE
fix: custom error page to bot-console home

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -5,6 +5,7 @@
   "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
     "AUTH0_DOMAIN": "e-bot7-production.eu.auth0.com",
     "AUTH0_TENANT_NAME": "e-bot7 Production",
+    "APP_ERROR_PAGE": "https://console.e-bot7.de/",
     "APP_ORIGINS": [
       "https://console.e-bot7.de/",
       "https://main-botconsole-1.production.e-bot7.de/",
@@ -21,7 +22,7 @@
   "AUTH0_ALLOW_DELETE": false,
   "AUTH0_EXCLUDED_RULES": [""],
   "EXCLUDED_PROPS": {
-   "clients": ["client_secret"],
+    "clients": ["client_secret"],
     "connections": ["options.client_secret"]
   }
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -5,6 +5,7 @@
   "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
     "AUTH0_DOMAIN": "e-bot7-staging.eu.auth0.com",
     "AUTH0_TENANT_NAME": "e-bot7 Staging",
+    "APP_ERROR_PAGE": "https://staging.e-bot7.de/",
     "APP_ORIGINS": [
       "https://staging.e-bot7.de/",
       "https://main-botconsole-1.staging.e-bot7.de/",

--- a/tenant.yaml
+++ b/tenant.yaml
@@ -6,9 +6,11 @@ rules:
     order: 1
 rulesConfigs: []
 hooks: []
-pages: []
+pages:
+  - name: error_page
+    url: ##APP_ERROR_PAGE##
 connections: []
-organizations: []
+organizations: []  
 resourceServers:
   - name: Bot Engine
     identifier: https://example.com/botengine


### PR DESCRIPTION
rather than showing auth0 default error page, configured with bot console home page.