### PR TITLE
fix: disable assign botengine member to org

### DIFF
--- a/migrations/lib/auth0.ts
+++ b/migrations/lib/auth0.ts
@@ -22,7 +22,6 @@ export class Auth0 {
       },
       {
         connection_id: this.config.getBotEngineConnectionDB(),
-        assign_membership_on_login: true,
       }
     );
   }


### PR DESCRIPTION
Assigning bot-engine members to org causing all bot-engine users mapped to different organisation.