### PR TITLE
Revert "fix: disable assign all botengine member to org"

### DIFF
--- a/migrations/lib/auth0.ts
+++ b/migrations/lib/auth0.ts
@@ -22,6 +22,7 @@ export class Auth0 {
       },
       {
         connection_id: this.config.getBotEngineConnectionDB(),
+        assign_membership_on_login: true,
       }
     );
   }


### PR DESCRIPTION
Reverts ebot7/auth0-integration#17